### PR TITLE
Add Koa settings to adgroup Post

### DIFF
--- a/Python/Campaign/Creating/CreateCampaignWorkflowREST.py
+++ b/Python/Campaign/Creating/CreateCampaignWorkflowREST.py
@@ -173,8 +173,20 @@ def create_and_associate_adgroup(campaign_id):
                 "CurrencyCode":"USD"
             },
             "CreativeIds":[
-            ]
+            ],
             #"AssociatedBidLists":[] If needed, add IDs of bid lists you want to associate with the ad group in the `AssociatedBidLists` array in the following format: `[ { "BidListId" : "id1" }, { "BidListId" : "id2" } , { "BidListId" : "id3" } ]`.
+            "KoaOptimizationSettings": {
+                "KoaDimensions": { # All Koa dimensions can be enabled/disabled in Koa V3.5. Koa V3.5 is off by default, and omitted dimensions will be disabled
+                    "AdFormat": True,
+                    "Geography": False,
+                    "Site": True,
+                    "AdEnvironment": True,
+                    "DeviceType": True,
+                    "Browser": False,
+                    "OS": True,
+                    "FoldPlacement": True
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Adding example koa V3.5 settings to the AdGroup POST function. Ran script and successfully created new Kokai Campaign/AdGroup with Koa dimensions set correctly.
![image](https://github.com/user-attachments/assets/1a28e02b-3139-490a-9d84-219db6be2d00)
